### PR TITLE
Version 2.11.0+ compatibility

### DIFF
--- a/library/Generictts/Ticket.php
+++ b/library/Generictts/Ticket.php
@@ -4,7 +4,7 @@
 namespace Icinga\Module\Generictts;
 
 use Icinga\Application\Config;
-use Icinga\Web\Hook\TicketHook;
+use Icinga\Application\Hook\TicketHook;
 
 /**
  * GenericTTS TicketHook implementation


### PR DESCRIPTION
I don't know enough about the Icingaweb ecosystem to know if we need to provide backward compatibility, or whether we can tag a new release that's only compatible w/ 2.11.0+ - so this may be insufficient.  But at least this should be helpful to anyone else who has Icingaweb2 troubles on upgrade to 2.11.

fixes #10 