### PR TITLE
Import `Icinga\Application\Hook\TicketHook` instead of `Icinga\Web\Hook\TicketHook` in `Ticket` class

### DIFF
--- a/library/Generictts/Ticket.php
+++ b/library/Generictts/Ticket.php
@@ -4,7 +4,7 @@
 namespace Icinga\Module\Generictts;
 
 use Icinga\Application\Config;
-use Icinga\Web\Hook\TicketHook;
+use Icinga\Application\Hook\TicketHook;
 
 /**
  * GenericTTS TicketHook implementation


### PR DESCRIPTION
Since Icinga Web 2 v2.11.0 `Icinga\Web\Hook\TicketHook` has been deprecated, hence `Icinga\Application\Hook\TicketHook`
needs to be used instead of `Icinga\Web\Hook\TicketHook`.

fixes #10