### PR TITLE
Add title attribute to anchor tag

### DIFF
--- a/library/Generictts/Ticket.php
+++ b/library/Generictts/Ticket.php
@@ -62,7 +62,7 @@ class Ticket extends TicketHook
     {
         /** @var \Icinga\Application\Hook\Ticket\TicketPattern $match */
         return sprintf(
-            '<a href="%s" target="_blank">%s</a>',
+            '<a href="%1$s" target="_blank" title="%1$s">%2$s</a>',
             preg_replace('/\$1/', rawurlencode($match[1]), $this->config->get($match->getName(), 'url')),
             $match[0]
         );


### PR DESCRIPTION
The title attribute is added to the anchor tag while creating the ticket link to show the url of the link upon hover.

## Before:
![ticket_link_before](https://user-images.githubusercontent.com/33730024/186903565-5b58972b-6991-4dfe-8480-d80dccffdcf6.png)

## After:
![ticket_link_after](https://user-images.githubusercontent.com/33730024/186903579-3b861078-1a75-44bc-a622-84ccaeed9ab9.png)

